### PR TITLE
Handle anonymous inline URDF materials

### DIFF
--- a/src/robot.cc
+++ b/src/robot.cc
@@ -46,6 +46,15 @@ static void storeVec4(const char* s, Vector4& vec) {
     CHECK_F(iss && (iss >> std::ws).eof(), "store_vec4: invalid string");
 }
 
+static std::string makeAnonymousInlineMaterialName(
+    const std::map<std::string, Material>& materials, size_t& anonymous_material_count) {
+    std::string name;
+    do {
+        name = fmt::format("__inline_material_{}", anonymous_material_count++);
+    } while (materials.find(name) != materials.end());
+    return name;
+}
+
 std::string resolveFilePath(const std::string& mesh_filename, const std::string& urdf_dir) {
     namespace fs = std::filesystem;
 
@@ -358,10 +367,6 @@ RobotPtr buildRobot(const char* urdf_file) {
     pugi::xml_node root_link = findRoot(doc);
     CHECK_F(not root_link.empty(), "No root link found");
 
-    auto tree_root = std::make_shared<LinkNode>();
-    tree_root->link = xmlNodeToLink(root_link, urdf_dir);
-    tree_root->w_T_l = MatrixIdentity();
-
     // Create all materials (global definitions first)
     std::map<std::string, Material> materials;
     for (pugi::xml_node& mat : doc.child("robot").children("material")) {
@@ -371,10 +376,18 @@ RobotPtr buildRobot(const char* urdf_file) {
     }
 
     // Promote inline material definitions (materials defined inside <visual>) to the global map
-    for (const pugi::xml_node& link : doc.child("robot").children("link")) {
-        for (const pugi::xml_node& vis : link.children("visual")) {
-            const pugi::xml_node& mat_node = vis.child("material");
+    size_t anonymous_material_count = 0;
+    for (pugi::xml_node link : doc.child("robot").children("link")) {
+        for (pugi::xml_node vis : link.children("visual")) {
+            pugi::xml_node mat_node = vis.child("material");
             if (mat_node && (mat_node.child("color") || mat_node.child("texture"))) {
+                pugi::xml_attribute name_attr = mat_node.attribute("name");
+                if (!name_attr || std::strlen(name_attr.as_string()) == 0) {
+                    if (!name_attr) name_attr = mat_node.append_attribute("name");
+                    const std::string generated_name =
+                        makeAnonymousInlineMaterialName(materials, anonymous_material_count);
+                    name_attr.set_value(generated_name.c_str());
+                }
                 if (const auto m = xmlNodeToMaterial(mat_node)) {
                     materials.insert({m->name, *m});
                 }
@@ -387,6 +400,10 @@ RobotPtr buildRobot(const char* urdf_file) {
             mat.texture_file = resolveFilePath(*mat.texture_file, urdf_dir);
         }
     }
+
+    auto tree_root = std::make_shared<LinkNode>();
+    tree_root->link = xmlNodeToLink(root_link, urdf_dir);
+    tree_root->w_T_l = MatrixIdentity();
 
     // TODO(ramon): every link uses the same shader, the material properties change the shader
     // color.
@@ -484,8 +501,8 @@ Link xmlNodeToLink(const pugi::xml_node& xml_node, const std::string& urdf_dir) 
 
         // --- Material
         if (const auto& mat_node = vis_node.child("material")) {
-            vis.material_name = mat_node.attribute("name").as_string();
-            CHECK_F(not vis.material_name->empty(), "Materials need to have a name!");
+            std::string material_name = mat_node.attribute("name").as_string();
+            if (not material_name.empty()) vis.material_name = material_name;
         }
 
         link.visual.push_back(vis);
@@ -610,7 +627,10 @@ std::optional<Material> xmlNodeToMaterial(const pugi::xml_node& mat_node) {
     Material mat;
 
     mat.name = mat_node.attribute("name").as_string();
-    CHECK_F(not mat.name.empty(), "Materials need to have a name!");
+    if (mat.name.empty()) {
+        LOG_F(WARNING, "Ignoring material without a name");
+        return std::nullopt;
+    }
 
     if (auto color_node = mat_node.child("color")) {
         CHECK_F(static_cast<bool>(color_node.attribute("rgba")),

--- a/tests/test_urdf_parsing.cc
+++ b/tests/test_urdf_parsing.cc
@@ -2,6 +2,9 @@
 #include <pugixml.hpp>
 #include <robot.h>
 
+#include <filesystem>
+#include <fstream>
+
 TEST_CASE("Material round-trip (color)") {
     pugi::xml_document doc;
     doc.load_string(R"(<material name="red"><color rgba="1 0 0 1"/></material>)");
@@ -484,6 +487,46 @@ TEST_CASE("Inline material promotion") {
     REQUIRE(materials["inline_red"].rgba.has_value());
     CHECK(materials["inline_red"].rgba->x == doctest::Approx(1.0f));
     CHECK(materials["inline_red"].rgba->y == doctest::Approx(0.0f));
+}
+
+TEST_CASE("Anonymous inline material gets generated name") {
+    const auto urdf_path =
+        std::filesystem::temp_directory_path() / "urdf_editor_anonymous_inline_material.urdf";
+
+    std::ofstream urdf_file(urdf_path);
+    urdf_file << R"(
+        <robot name="test">
+            <link name="base_link">
+                <visual>
+                    <geometry><box size="1 1 1"/></geometry>
+                    <material name="">
+                        <color rgba="0.1 0.2 0.3 1"/>
+                    </material>
+                </visual>
+            </link>
+        </robot>
+    )";
+    urdf_file.close();
+
+    auto robot = urdf::buildRobot(urdf_path.string().c_str());
+
+    REQUIRE(robot);
+    REQUIRE(robot->getRoot());
+    REQUIRE(robot->getRoot()->link.visual.size() == 1);
+    REQUIRE(robot->getRoot()->link.visual[0].material_name.has_value());
+
+    const std::string material_name = *robot->getRoot()->link.visual[0].material_name;
+    CHECK(material_name == "__inline_material_0");
+
+    const auto& materials = robot->getMaterials();
+    REQUIRE(materials.count(material_name) == 1);
+    REQUIRE(materials.at(material_name).rgba.has_value());
+    CHECK(materials.at(material_name).rgba->x == doctest::Approx(0.1f));
+    CHECK(materials.at(material_name).rgba->y == doctest::Approx(0.2f));
+    CHECK(materials.at(material_name).rgba->z == doctest::Approx(0.3f));
+    CHECK(materials.at(material_name).rgba->w == doctest::Approx(1.0f));
+
+    std::filesystem::remove(urdf_path);
 }
 
 TEST_CASE("Inertial round-trip") {


### PR DESCRIPTION
Generate stable internal names for inline visual materials that contain color or texture data but have an empty name attribute. This preserves SolidWorks-exported material colors/textures instead of aborting during import.