### PR TITLE
Fix URDF geometry transforms

### DIFF
--- a/include/robot.h
+++ b/include/robot.h
@@ -12,15 +12,15 @@
 
 namespace urdf {
 
-// Extract XYZ intrinsic Euler angles (roll-pitch-yaw) from a rotation matrix.
-// Uses the convention: R = Rx(roll) * Ry(pitch) * Rz(yaw).
+// Extract URDF fixed-axis roll-pitch-yaw from a rotation matrix.
+// Uses the convention: R = Rz(yaw) * Ry(pitch) * Rx(roll).
 // Assumes no gimbal lock (pitch != +/-90 degrees).
 inline Vector3 MatrixToXYZ(const Matrix& m) {
     Vector3 xyz{Vector3Zero()};
 
-    xyz.x = std::atan2(-m.m9, m.m10);
-    xyz.y = std::atan2(m.m8, std::sqrt(m.m0 * m.m0 + m.m4 * m.m4));
-    xyz.z = std::atan2(-m.m4, m.m0);
+    xyz.x = std::atan2(m.m6, m.m10);
+    xyz.y = std::atan2(-m.m2, std::sqrt(m.m0 * m.m0 + m.m1 * m.m1));
+    xyz.z = std::atan2(m.m1, m.m0);
 
     return xyz;
 }
@@ -306,7 +306,7 @@ class Robot {
 
    private:
     void loadTextureForMaterial(const std::string& name, const Material& mat);
-    static Matrix originToMatrix(std::optional<Origin>& origin);
+    static Matrix originToMatrix(const std::optional<Origin>& origin);
 
     LinkNodePtr root_;
 

--- a/src/import_mesh.cc
+++ b/src/import_mesh.cc
@@ -4,6 +4,7 @@
 
 #include <assimp/Importer.hpp>
 #include <loguru.hpp>
+#include <raymath.h>
 
 ::Mesh GenMeshCenteredCylinder(float radius, float height, int slices) {
     ::Mesh mesh = {0};
@@ -126,6 +127,7 @@ std::vector<Mesh> LoadMeshesFromFile(const std::string& filename) {
 
 Model LoadModelFromFile(const std::string& filename) {
     Model model = {};
+    model.transform = MatrixIdentity();
     std::vector<Mesh> meshes = LoadMeshesFromFile(filename);
     model.meshCount = meshes.size();
     model.meshes = (Mesh*)RL_MALLOC(model.meshCount * sizeof(Mesh));

--- a/src/robot.cc
+++ b/src/robot.cc
@@ -100,7 +100,7 @@ Origin::Origin(const char* xyz_s, const char* rpy_s) {
 Origin::Origin(const Vector3& xyz, const Vector3& rpy) : xyz(xyz), rpy(rpy) {}
 
 Matrix Origin::toMatrix() const {
-    Matrix rot_mat{MatrixRotateXYZ(rpy)};
+    Matrix rot_mat{MatrixRotateZYX(rpy)};
     Matrix pos_mat{MatrixTranslate(xyz.x, xyz.y, xyz.z)};
     return MatrixMultiply(rot_mat, pos_mat);
 }
@@ -904,6 +904,21 @@ void Robot::forwardKinematics() { forwardKinematics(root_); }
 // (no joint-to-child offset currently). Visual and collision transforms
 // are then composed on top: w_T_visual = w_T_child * c_T_visual.
 void Robot::forwardKinematics(LinkNodePtr& link) {
+    auto update_link_models = [](const LinkNodePtr& node) {
+        for (size_t i = 0; i < node->visual_models.size() && i < node->link.visual.size(); ++i) {
+            const Matrix l_t_v = originToMatrix(node->link.visual[i].origin);
+            node->visual_models[i].transform = MatMul(node->w_T_l, l_t_v);
+        }
+
+        for (size_t i = 0; i < node->collision_models.size() && i < node->link.collision.size();
+             ++i) {
+            const Matrix l_t_col = originToMatrix(node->link.collision[i].origin);
+            node->collision_models[i].transform = MatMul(node->w_T_l, l_t_col);
+        }
+    };
+
+    update_link_models(link);
+
     std::function<void(LinkNodePtr&)> recursion = [&](LinkNodePtr& node) {
         const Matrix& w_t_p = node->w_T_l;
 
@@ -922,21 +937,7 @@ void Robot::forwardKinematics(LinkNodePtr& link) {
             }
             const Matrix w_t_c = MatMul(w_t_p, MatMul(p_t_j, j_t_c));
             joint_node->child->w_T_l = w_t_c;
-
-            // Update visual transforms
-            for (size_t i = 0; i < joint_node->child->visual_models.size(); ++i) {
-                auto& vis_origin = joint_node->child->link.visual[i].origin;
-                const Matrix c_t_v = originToMatrix(vis_origin);
-                const Matrix w_t_v = MatMul(w_t_c, c_t_v);
-                joint_node->child->visual_models[i].transform = w_t_v;
-            }
-
-            // Update collision transforms
-            for (size_t i = 0; i < joint_node->child->collision_models.size(); ++i) {
-                const Matrix c_t_col = originToMatrix(joint_node->child->link.collision[i].origin);
-                const Matrix w_t_col = MatMul(w_t_c, c_t_col);
-                joint_node->child->collision_models[i].transform = w_t_col;
-            }
+            update_link_models(joint_node->child);
 
             recursion(joint_node->child);
         }
@@ -945,7 +946,7 @@ void Robot::forwardKinematics(LinkNodePtr& link) {
     recursion(link);
 }
 
-Matrix Robot::originToMatrix(std::optional<Origin>& origin) {
+Matrix Robot::originToMatrix(const std::optional<Origin>& origin) {
     return origin ? origin->toMatrix() : MatrixIdentity();
 }
 

--- a/src/robot.cc
+++ b/src/robot.cc
@@ -28,6 +28,13 @@ static inline Matrix MatMul(const Matrix& left, const Matrix& right) {
     return MatrixMultiply(right, left);
 }
 
+static Matrix geometryLocalTransform(const Geometry& geometry) {
+    const auto mesh = std::dynamic_pointer_cast<Mesh>(geometry.type);
+    if (!mesh) return MatrixIdentity();
+
+    return MatrixScale(mesh->scale.x, mesh->scale.y, mesh->scale.z);
+}
+
 static void storeFloat(const char* s, float& f) {
     std::stringstream iss(s);
     iss >> f;
@@ -907,13 +914,18 @@ void Robot::forwardKinematics(LinkNodePtr& link) {
     auto update_link_models = [](const LinkNodePtr& node) {
         for (size_t i = 0; i < node->visual_models.size() && i < node->link.visual.size(); ++i) {
             const Matrix l_t_v = originToMatrix(node->link.visual[i].origin);
-            node->visual_models[i].transform = MatMul(node->w_T_l, l_t_v);
+            const Matrix v_t_geometry = geometryLocalTransform(node->link.visual[i].geometry);
+            node->visual_models[i].transform =
+                MatMul(node->w_T_l, MatMul(l_t_v, v_t_geometry));
         }
 
         for (size_t i = 0; i < node->collision_models.size() && i < node->link.collision.size();
              ++i) {
             const Matrix l_t_col = originToMatrix(node->link.collision[i].origin);
-            node->collision_models[i].transform = MatMul(node->w_T_l, l_t_col);
+            const Matrix col_t_geometry =
+                geometryLocalTransform(node->link.collision[i].geometry);
+            node->collision_models[i].transform =
+                MatMul(node->w_T_l, MatMul(l_t_col, col_t_geometry));
         }
     };
 

--- a/tests/test_origin_math.cc
+++ b/tests/test_origin_math.cc
@@ -106,6 +106,53 @@ TEST_CASE("Forward kinematics updates root visual transform") {
     CHECK(root->visual_models[0].transform.m14 == doctest::Approx(3.75f));
 }
 
+TEST_CASE("Forward kinematics preserves root mesh scale") {
+    auto root = std::make_shared<urdf::LinkNode>(urdf::Link("root"), nullptr);
+    root->w_T_l = MatrixTranslate(1.0f, 2.0f, 3.0f);
+
+    urdf::Visual visual;
+    visual.origin = urdf::Origin(Vector3{0.25f, 0.5f, 0.75f}, Vector3{0.0f, 0.0f, PI / 2.0f});
+    visual.geometry.type =
+        std::make_shared<urdf::Mesh>("visual.stl", "", Vector3{2.0f, 3.0f, 4.0f});
+    root->link.visual.push_back(visual);
+    root->visual_models.push_back(Model{});
+
+    urdf::Collision collision;
+    collision.origin =
+        urdf::Origin(Vector3{-0.25f, -0.5f, -0.75f}, Vector3{0.0f, PI / 2.0f, 0.0f});
+    collision.geometry.type =
+        std::make_shared<urdf::Mesh>("collision.stl", "", Vector3{5.0f, 6.0f, 7.0f});
+    root->link.collision.push_back(collision);
+    root->collision_models.push_back(Model{});
+
+    // Repeated updates must rebuild the model transforms without accumulating scale.
+    urdf::Robot::forwardKinematics(root);
+    urdf::Robot::forwardKinematics(root);
+
+    const Matrix& visual_transform = root->visual_models[0].transform;
+    CHECK(Vector3Length({visual_transform.m0, visual_transform.m1, visual_transform.m2}) ==
+          doctest::Approx(2.0f));
+    CHECK(Vector3Length({visual_transform.m4, visual_transform.m5, visual_transform.m6}) ==
+          doctest::Approx(3.0f));
+    CHECK(Vector3Length({visual_transform.m8, visual_transform.m9, visual_transform.m10}) ==
+          doctest::Approx(4.0f));
+    CHECK(visual_transform.m12 == doctest::Approx(1.25f));
+    CHECK(visual_transform.m13 == doctest::Approx(2.5f));
+    CHECK(visual_transform.m14 == doctest::Approx(3.75f));
+
+    const Matrix& collision_transform = root->collision_models[0].transform;
+    CHECK(Vector3Length({collision_transform.m0, collision_transform.m1, collision_transform.m2}) ==
+          doctest::Approx(5.0f));
+    CHECK(Vector3Length({collision_transform.m4, collision_transform.m5, collision_transform.m6}) ==
+          doctest::Approx(6.0f));
+    CHECK(Vector3Length(
+              {collision_transform.m8, collision_transform.m9, collision_transform.m10}) ==
+          doctest::Approx(7.0f));
+    CHECK(collision_transform.m12 == doctest::Approx(0.75f));
+    CHECK(collision_transform.m13 == doctest::Approx(1.5f));
+    CHECK(collision_transform.m14 == doctest::Approx(2.25f));
+}
+
 TEST_CASE("Forward kinematics keeps Diablo wheel assemblies on correct sides") {
     auto root = std::make_shared<urdf::LinkNode>(urdf::Link("base_link"), nullptr);
 

--- a/tests/test_origin_math.cc
+++ b/tests/test_origin_math.cc
@@ -68,3 +68,121 @@ TEST_CASE("RPY round-trip through matrix") {
         CHECK(recovered.z == doctest::Approx(rpy.z).epsilon(1e-4));
     }
 }
+
+TEST_CASE("URDF RPY uses fixed-axis roll pitch yaw") {
+    urdf::Origin o({0, 0, 0}, {PI / 2.0f, 0.0f, PI / 2.0f});
+    Matrix m = o.toMatrix();
+
+    Vector3 x_axis = Vector3Transform({1.0f, 0.0f, 0.0f}, m);
+    Vector3 y_axis = Vector3Transform({0.0f, 1.0f, 0.0f}, m);
+    Vector3 z_axis = Vector3Transform({0.0f, 0.0f, 1.0f}, m);
+
+    CHECK(x_axis.x == doctest::Approx(0.0f).epsilon(1e-5));
+    CHECK(x_axis.y == doctest::Approx(1.0f).epsilon(1e-5));
+    CHECK(x_axis.z == doctest::Approx(0.0f).epsilon(1e-5));
+
+    CHECK(y_axis.x == doctest::Approx(0.0f).epsilon(1e-5));
+    CHECK(y_axis.y == doctest::Approx(0.0f).epsilon(1e-5));
+    CHECK(y_axis.z == doctest::Approx(1.0f).epsilon(1e-5));
+
+    CHECK(z_axis.x == doctest::Approx(1.0f).epsilon(1e-5));
+    CHECK(z_axis.y == doctest::Approx(0.0f).epsilon(1e-5));
+    CHECK(z_axis.z == doctest::Approx(0.0f).epsilon(1e-5));
+}
+
+TEST_CASE("Forward kinematics updates root visual transform") {
+    auto root = std::make_shared<urdf::LinkNode>(urdf::Link("root"), nullptr);
+    root->w_T_l = MatrixTranslate(1.0f, 2.0f, 3.0f);
+
+    urdf::Visual visual;
+    visual.origin = urdf::Origin(Vector3{0.25f, 0.5f, 0.75f}, Vector3{0.0f, 0.0f, 0.0f});
+    root->link.visual.push_back(visual);
+    root->visual_models.push_back(Model{});
+
+    urdf::Robot::forwardKinematics(root);
+
+    CHECK(root->visual_models[0].transform.m12 == doctest::Approx(1.25f));
+    CHECK(root->visual_models[0].transform.m13 == doctest::Approx(2.5f));
+    CHECK(root->visual_models[0].transform.m14 == doctest::Approx(3.75f));
+}
+
+TEST_CASE("Forward kinematics keeps Diablo wheel assemblies on correct sides") {
+    auto root = std::make_shared<urdf::LinkNode>(urdf::Link("base_link"), nullptr);
+
+    auto left_motor = std::make_shared<urdf::LinkNode>(urdf::Link("left_motor"), nullptr);
+    auto left_j4 = std::make_shared<urdf::JointNode>(
+        urdf::Joint("left_j4", "base_link", "left_motor", "continuous"), root, left_motor);
+    left_j4->joint.origin = urdf::Origin(Vector3{0.0f, 0.18755f, 0.0f},
+                                         Vector3{1.5708f, 0.13433f, -3.1416f});
+    left_motor->parent = left_j4;
+    root->children.push_back(left_j4);
+
+    auto left_leg1 = std::make_shared<urdf::LinkNode>(urdf::Link("left_leg1"), nullptr);
+    auto left_j1 = std::make_shared<urdf::JointNode>(
+        urdf::Joint("left_j1", "left_motor", "left_leg1", "continuous"), left_motor, left_leg1);
+    left_j1->joint.origin =
+        urdf::Origin(Vector3{0.0f, 0.0f, 0.0f}, Vector3{0.0f, 0.0f, -2.8729f});
+    left_leg1->parent = left_j1;
+    left_motor->children.push_back(left_j1);
+
+    auto left_leg2 = std::make_shared<urdf::LinkNode>(urdf::Link("left_leg2"), nullptr);
+    auto left_j2 = std::make_shared<urdf::JointNode>(
+        urdf::Joint("left_j2", "left_leg1", "left_leg2", "continuous"), left_leg1, left_leg2);
+    left_j2->joint.origin =
+        urdf::Origin(Vector3{0.14f, 0.0f, 0.0f}, Vector3{0.0f, 0.0f, 2.8729f});
+    left_leg2->parent = left_j2;
+    left_leg1->children.push_back(left_j2);
+
+    auto left_wheel = std::make_shared<urdf::LinkNode>(urdf::Link("left_wheel"), nullptr);
+    auto left_j3 = std::make_shared<urdf::JointNode>(
+        urdf::Joint("left_j3", "left_leg2", "left_wheel", "continuous"), left_leg2, left_wheel);
+    left_j3->joint.origin =
+        urdf::Origin(Vector3{0.14f, 0.0f, 0.0537f}, Vector3{0.0f, 0.0f, 0.13433f});
+    left_wheel->parent = left_j3;
+    left_leg2->children.push_back(left_j3);
+
+    auto right_motor = std::make_shared<urdf::LinkNode>(urdf::Link("right_motor"), nullptr);
+    auto right_j4 = std::make_shared<urdf::JointNode>(
+        urdf::Joint("right_j4", "base_link", "right_motor", "continuous"), root, right_motor);
+    right_j4->joint.origin = urdf::Origin(Vector3{0.0f, -0.18755f, 0.0f},
+                                          Vector3{1.5708f, 0.13433f, 3.1416f});
+    right_motor->parent = right_j4;
+    root->children.push_back(right_j4);
+
+    auto right_leg1 = std::make_shared<urdf::LinkNode>(urdf::Link("right_leg1"), nullptr);
+    auto right_j1 = std::make_shared<urdf::JointNode>(
+        urdf::Joint("right_j1", "right_motor", "right_leg1", "continuous"), right_motor,
+        right_leg1);
+    right_j1->joint.origin =
+        urdf::Origin(Vector3{0.0f, 0.0f, 0.0f}, Vector3{0.0f, 0.0f, -2.8729f});
+    right_leg1->parent = right_j1;
+    right_motor->children.push_back(right_j1);
+
+    auto right_leg2 = std::make_shared<urdf::LinkNode>(urdf::Link("right_leg2"), nullptr);
+    auto right_j2 = std::make_shared<urdf::JointNode>(
+        urdf::Joint("right_j2", "right_leg1", "right_leg2", "continuous"), right_leg1,
+        right_leg2);
+    right_j2->joint.origin =
+        urdf::Origin(Vector3{0.14f, 0.0f, 0.0f}, Vector3{0.0f, 0.0f, 2.8729f});
+    right_leg2->parent = right_j2;
+    right_leg1->children.push_back(right_j2);
+
+    auto right_wheel = std::make_shared<urdf::LinkNode>(urdf::Link("right_wheel"), nullptr);
+    auto right_j3 = std::make_shared<urdf::JointNode>(
+        urdf::Joint("right_j3", "right_leg2", "right_wheel", "continuous"), right_leg2,
+        right_wheel);
+    right_j3->joint.origin =
+        urdf::Origin(Vector3{0.14f, 0.0f, -0.0537f}, Vector3{0.0f, 0.0f, -3.0073f});
+    right_wheel->parent = right_j3;
+    right_leg2->children.push_back(right_j3);
+
+    urdf::Robot::forwardKinematics(root);
+
+    CHECK(left_wheel->w_T_l.m12 == doctest::Approx(0.0f).epsilon(1e-4));
+    CHECK(left_wheel->w_T_l.m13 == doctest::Approx(0.2412f).epsilon(1e-4));
+    CHECK(left_wheel->w_T_l.m14 == doctest::Approx(-0.0375f).epsilon(1e-4));
+
+    CHECK(right_wheel->w_T_l.m12 == doctest::Approx(0.0f).epsilon(1e-4));
+    CHECK(right_wheel->w_T_l.m13 == doctest::Approx(-0.2412f).epsilon(1e-4));
+    CHECK(right_wheel->w_T_l.m14 == doctest::Approx(-0.0375f).epsilon(1e-4));
+}


### PR DESCRIPTION
Initialize imported model transforms, update root link visual/collision transforms during FK, and use URDF fixed-axis roll-pitch-yaw composition. Adds regressions for root visual transforms and Diablo-style left/right wheel placement.